### PR TITLE
Fix session closing issue

### DIFF
--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -3,6 +3,7 @@
 import os
 import pep8
 import unittest
+import models
 from unittest.mock import patch
 from io import StringIO
 from console import HBNBCommand
@@ -38,6 +39,7 @@ class TestHBNBCommand(unittest.TestCase):
         except IOError:
             pass
         del cls.HBNB
+        models.storage._DBStorage__session.close()
 
     def setUp(self):
         """Reset FileStorage objects dictionary."""

--- a/tests/test_models/test_amenity.py
+++ b/tests/test_models/test_amenity.py
@@ -5,12 +5,12 @@ import pep8
 import MySQLdb
 import unittest
 from datetime import datetime
-from models.base_model import Base, BaseModel
+from models.base_model import Base
+from models.base_model import BaseModel
 from models.amenity import Amenity
 from models.engine.db_storage import DBStorage
 from models.engine.file_storage import FileStorage
 from sqlalchemy.exc import OperationalError
-from sqlalchemy.orm import scoped_session
 from sqlalchemy.orm import sessionmaker
 
 
@@ -20,6 +20,7 @@ class TestAmenity(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Amenity testing setup.
+
         Temporarily renames any existing file.json.
         Resets FileStorage objects dictionary.
         Creates FileStorage, DBStorage and Amenity instances for testing.
@@ -36,9 +37,7 @@ class TestAmenity(unittest.TestCase):
             return
         cls.dbstorage = DBStorage()
         Base.metadata.create_all(cls.dbstorage._DBStorage__engine)
-        session_factory = sessionmaker(bind=cls.dbstorage._DBStorage__engine,
-                                       expire_on_commit=False)
-        Session = scoped_session(session_factory)
+        Session = sessionmaker(bind=cls.dbstorage._DBStorage__engine)
         cls.dbstorage._DBStorage__session = Session()
 
     @classmethod

--- a/tests/test_models/test_city.py
+++ b/tests/test_models/test_city.py
@@ -12,7 +12,6 @@ from models.state import State
 from models.engine.db_storage import DBStorage
 from models.engine.file_storage import FileStorage
 from sqlalchemy.exc import OperationalError
-from sqlalchemy.orm import scoped_session
 from sqlalchemy.orm import sessionmaker
 
 
@@ -40,9 +39,7 @@ class TestCity(unittest.TestCase):
             return
         cls.dbstorage = DBStorage()
         Base.metadata.create_all(cls.dbstorage._DBStorage__engine)
-        session_factory = sessionmaker(bind=cls.dbstorage._DBStorage__engine,
-                                       expire_on_commit=False)
-        Session = scoped_session(session_factory)
+        Session = sessionmaker(bind=cls.dbstorage._DBStorage__engine)
         cls.dbstorage._DBStorage__session = Session()
 
     @classmethod

--- a/tests/test_models/test_engine/test_db_storage.py
+++ b/tests/test_models/test_engine/test_db_storage.py
@@ -12,7 +12,6 @@ from models.amenity import Amenity
 from models.place import Place
 from models.review import Review
 from models.engine.db_storage import DBStorage
-from sqlalchemy.orm import scoped_session
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.session import Session
 from sqlalchemy.engine.base import Engine
@@ -32,9 +31,7 @@ class TestDBStorage(unittest.TestCase):
             return
         cls.storage = DBStorage()
         Base.metadata.create_all(cls.storage._DBStorage__engine)
-        session_factory = sessionmaker(bind=cls.storage._DBStorage__engine,
-                                       expire_on_commit=False)
-        Session = scoped_session(session_factory)
+        Session = sessionmaker(bind=cls.storage._DBStorage__engine)
         cls.storage._DBStorage__session = Session()
         cls.state = State(name="California")
         cls.storage._DBStorage__session.add(cls.state)

--- a/tests/test_models/test_place.py
+++ b/tests/test_models/test_place.py
@@ -14,7 +14,6 @@ from models.user import User
 from models.engine.db_storage import DBStorage
 from models.engine.file_storage import FileStorage
 from sqlalchemy.exc import OperationalError
-from sqlalchemy.orm import scoped_session
 from sqlalchemy.orm import sessionmaker
 
 
@@ -45,9 +44,7 @@ class TestPlace(unittest.TestCase):
             return
         cls.dbstorage = DBStorage()
         Base.metadata.create_all(cls.dbstorage._DBStorage__engine)
-        session_factory = sessionmaker(bind=cls.dbstorage._DBStorage__engine,
-                                       expire_on_commit=False)
-        Session = scoped_session(session_factory)
+        Session = sessionmaker(bind=cls.dbstorage._DBStorage__engine)
         cls.dbstorage._DBStorage__session = Session()
 
     @classmethod

--- a/tests/test_models/test_review.py
+++ b/tests/test_models/test_review.py
@@ -15,7 +15,6 @@ from models.review import Review
 from models.engine.db_storage import DBStorage
 from models.engine.file_storage import FileStorage
 from sqlalchemy.exc import OperationalError
-from sqlalchemy.orm import scoped_session
 from sqlalchemy.orm import sessionmaker
 
 
@@ -47,9 +46,7 @@ class TestReview(unittest.TestCase):
             return
         cls.dbstorage = DBStorage()
         Base.metadata.create_all(cls.dbstorage._DBStorage__engine)
-        session_factory = sessionmaker(bind=cls.dbstorage._DBStorage__engine,
-                                       expire_on_commit=False)
-        Session = scoped_session(session_factory)
+        Session = sessionmaker(bind=cls.dbstorage._DBStorage__engine)
         cls.dbstorage._DBStorage__session = Session()
 
     @classmethod

--- a/tests/test_models/test_state.py
+++ b/tests/test_models/test_state.py
@@ -10,7 +10,6 @@ from models.state import State
 from models.engine.db_storage import DBStorage
 from models.engine.file_storage import FileStorage
 from sqlalchemy.exc import OperationalError
-from sqlalchemy.orm import scoped_session
 from sqlalchemy.orm import sessionmaker
 
 
@@ -32,16 +31,12 @@ class TestState(unittest.TestCase):
         FileStorage._FileStorage__objects = {}
         cls.filestorage = FileStorage()
         cls.state = State(name="California")
-        key = "{}.{}".format(type(cls.state).__name__, cls.state)
-        cls.filestorage._FileStorage__objects[key] = cls.state
 
         if os.getenv("HBNB_ENV") is None:
             return
         cls.dbstorage = DBStorage()
         Base.metadata.create_all(cls.dbstorage._DBStorage__engine)
-        session_factory = sessionmaker(bind=cls.dbstorage._DBStorage__engine,
-                                       expire_on_commit=False)
-        Session = scoped_session(session_factory)
+        Session = sessionmaker(bind=cls.dbstorage._DBStorage__engine)
         cls.dbstorage._DBStorage__session = Session()
 
     @classmethod
@@ -145,7 +140,7 @@ class TestState(unittest.TestCase):
         cursor = db.cursor()
         cursor.execute("SELECT * \
                           FROM `states` \
-                         WHERE BINARY name = '{}'".\
+                         WHERE BINARY name = '{}'".
                        format(self.state.name))
         query = cursor.fetchall()
         self.assertEqual(1, len(query))

--- a/tests/test_models/test_user.py
+++ b/tests/test_models/test_user.py
@@ -10,7 +10,6 @@ from models.user import User
 from models.engine.db_storage import DBStorage
 from models.engine.file_storage import FileStorage
 from sqlalchemy.exc import OperationalError
-from sqlalchemy.orm import scoped_session
 from sqlalchemy.orm import sessionmaker
 
 
@@ -37,9 +36,7 @@ class TestUser(unittest.TestCase):
             return
         cls.dbstorage = DBStorage()
         Base.metadata.create_all(cls.dbstorage._DBStorage__engine)
-        session_factory = sessionmaker(bind=cls.dbstorage._DBStorage__engine,
-                                       expire_on_commit=False)
-        Session = scoped_session(session_factory)
+        Session = sessionmaker(bind=cls.dbstorage._DBStorage__engine)
         cls.dbstorage._DBStorage__session = Session()
 
     @classmethod


### PR DESCRIPTION
Fixed the issue causing the test suite to freeze. Closed `models.storage.session` in the tear down of `test_console.py`.

Also, swapped out the session generation in the set up of each model test file to be a simply session maker, not a scoped session.